### PR TITLE
Rename functions and remove unwanted recursion

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -473,16 +473,10 @@ function makeWordNet(input_path){
 				return promise.nodeify(callback);
 			  },
 			  getHyponyms: function(callback){
-				  function getHyponymsFromId(input){
-						return _findHyponymsArray(input).map(_appendLemmas).map(function(item){
-							return Promise.props(item);
-						}).map(function(item){
-							var obj = new wn.Synset(item);
-							return obj;
-						});	
-					}  
-					var promise = getHyponymsFromId(this.synsetid);
-					return promise.nodeify(callback);
+				  var promise = _findHyponymsArray(this.synsetid).map(_appendLemmas).map(function(item){
+					   return new wn.Synset(item);
+				  });
+				  return promise.nodeify(callback);			  
 			  },
 			  getHyponymsTree: function(callback){
 				  function getHyponymsFromId(input){


### PR DESCRIPTION
I did some small changes that you might like to have a too! 
- README.md refers to getHypernyms and getHypernymsTree, so i changed this accordingly. It makes sense since some words have multiple hypernyms "dog" for instance has both _canid_ and _domestic animal_
- getHyponyms for some reason recurs through the whole tree if I understood it right. This is superheavy if you for instance need to have hyponyms abstract word such as _entity_.

Awesome tool! I like it alot :D
